### PR TITLE
Smb badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: ["**"]
+  push:
+    branches: [main]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Welcome to Prometheus, an open-source neutrino telescope simulation.
 
-<!-- Badges: CI, Docs, Coverage, Python versions, License -->
+<!-- Badges: CI, Docs, Python versions, License -->
 [![CI](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml)
 [![Docs](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/deploy-mkdocs.yml/badge.svg?branch=main)](https://harvard-neutrino.github.io/prometheus/)
-[![Coverage](https://codecov.io/gh/Harvard-Neutrino/prometheus/branch/main/graph/badge.svg)](https://codecov.io/gh/Harvard-Neutrino/prometheus)
 [![Python Versions](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue)](https://www.python.org/)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Welcome to Prometheus, an open-source neutrino telescope simulation.
 
+<!-- Badges: CI, Docs, Coverage, Python versions, License -->
+[![CI](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml)
+[![Docs](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/deploy-mkdocs.yml/badge.svg?branch=main)](https://harvard-neutrino.github.io/prometheus/)
+[![Coverage](https://codecov.io/gh/Harvard-Neutrino/prometheus/branch/main/graph/badge.svg)](https://codecov.io/gh/Harvard-Neutrino/prometheus)
+[![Python Versions](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue)](https://www.python.org/)
+[![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
 |              |                                                  |
 |--------------|--------------------------------------------------|
 |Repository    | <https://github.com/Harvard-Neutrino/prometheus> |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Welcome to Prometheus, an open-source neutrino telescope simulation.
 
 <!-- Badges: CI, Docs, Python versions, License -->
-[![CI](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml)
+[![CI](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml/badge.svg?branch=smb-badges)](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml)
 [![Docs](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/deploy-mkdocs.yml/badge.svg?branch=main)](https://harvard-neutrino.github.io/prometheus/)
 [![Python Versions](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue)](https://www.python.org/)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Welcome to Prometheus, an open-source neutrino telescope simulation.
 
 <!-- Badges: CI, Docs, Python versions, License -->
-[![CI](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml/badge.svg?branch=smb-badges)](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml)
+[![CI](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/ci.yml)
 [![Docs](https://github.com/Harvard-Neutrino/prometheus/actions/workflows/deploy-mkdocs.yml/badge.svg?branch=main)](https://harvard-neutrino.github.io/prometheus/)
 [![Python Versions](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue)](https://www.python.org/)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)


### PR DESCRIPTION
## What changed

- **`README.md`**: Removed the Codecov coverage badge.
- **`.github/workflows/ci.yml`**: Added a `push: branches: [main]` trigger alongside the existing `pull_request` trigger.

## Why

The coverage badge pointed to Codecov, but the CI pipeline never uploads coverage data, so the badge permanently showed "unknown". Removing it avoids misleading users.

The CI badge was also showing "unknown" because the workflow only triggered on `pull_request`. GitHub's badge API resolves `?branch=main` by looking for runs triggered directly on that branch — a PR-only workflow never produces such a run. Adding the `push` trigger means the workflow runs on every merge to `main`, keeping the badge up to date.

## Related Issues

<!-- Mention any Issues this PR is related to. -->

## How to test or reproduce the change

After this PR is merged, the CI badge in the README should update to "passing" once the workflow completes on `main`.

## Checklist

- [✅] My branch is up to date with the main branch
- [✅] Code compiles without errors and works
- [✅] Code changes include relevant comments, docstrings, and unit tests
- [✅] All unit tests pass
- [✅] Documentation is updated in line with [style standards](../CONTRIBUTING.md#style-guides-checks-and-best-practices)
- [✅] Changes to the documentation were [manually tested](../CONTRIBUTING.md#testing-your-documentation-changes) on the documentation site

## Additional Notes

The CI badge will show "no status" until the first merge to `main` after this PR lands — that is expected.
<img width="812" height="523" alt="Screenshot 2026-04-27 161746" src="https://github.com/user-attachments/assets/96c89e70-23f0-4d85-90fe-d253a6d4f5a2" />
