### PR TITLE
Fix lower case issue

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/prometheus
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # ─── CPU image ─────────────────────────────────────────────────────────────
@@ -39,6 +40,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -77,6 +81,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
# Describe your changes

## What changed

Two fixes to `.github/workflows/docker-publish.yml`:

- Added a `Lowercase image name` step in both the CPU and GPU jobs that pipes `IMAGE_NAME` through `tr '[:upper:]' '[:lower:]'` before it is used in any subsequent step.
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the top-level `env` block to opt the Docker actions into Node.js 24 ahead of the GitHub-enforced cutover in June 2026.

## Why

Running the workflow produced two errors:

1. `ERROR: failed to build: invalid tag "ghcr.io/Harvard-Neutrino/prometheus:v1.0.0": repository name must be lowercase` — GHCR requires all image names to be lowercase, but `github.repository_owner` preserves the casing of the organisation name (`Harvard-Neutrino`).
2. Deprecation warnings for `docker/login-action@v3`, `docker/setup-buildx-action@v3`, and `docker/build-push-action@v6` running on Node.js 20, which will be removed from GitHub runners in September 2026.

## Related Issues

None.

## How to test or reproduce the change

Trigger the **Publish Docker images** workflow manually via `workflow_dispatch` with any version string (e.g. `v1.0.0`) and variant `cpu` or `both`. Both jobs should complete without the lowercase tag error and without Node.js deprecation warnings.

## Checklist

- [x] My branch is up to date with the main branch
- [x] Code compiles without errors and works
- [x] Code changes include relevant comments, docstrings, and unit tests — *no application code changed; CI config only*
- [x] All unit tests pass — *no application code changed*
- [x] Documentation is updated in line with [style standards](../CONTRIBUTING.md#style-guides-checks-and-best-practices) — *no documentation changes required*
- [x] Changes to the documentation were [manually tested](../CONTRIBUTING.md#testing-your-documentation-changes) on the documentation site — *no documentation changes required*

## Additional Notes

The root cause of the lowercase issue is that `github.repository_owner` reflects the exact casing of the GitHub organisation or user account name. GitHub Actions does not provide a built-in lowercase filter in expression syntax, so the `tr` shell step is the idiomatic workaround. The `IMAGE_NAME` workflow-level env var is left unchanged so it remains readable; the lowercased override only takes effect within each job via `$GITHUB_ENV`.
