### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Welcome to Prometheus, an open-source neutrino telescope simulation.
 |              |                                                  |
 |--------------|--------------------------------------------------|
 |Repository    | <https://github.com/Harvard-Neutrino/prometheus> |
-|ArXiv paper   | <http://arxiv.org/abs/2304.1452>                 |
+|ArXiv paper   | <https://arxiv.org/pdf/2304.14526>                 |
 |Documentation | <https://harvard-neutrino.github.io/prometheus/> |
 
 ## Summary


### PR DESCRIPTION
Fix link to paper

# Describe your changes

We were providing the wrong link

## What changed

Link changed to https://arxiv.org/pdf/2304.14526 in the readme.md

## Why

Wrong paper was linked

## Related Issues

#99 pointed this out

## How to test or reproduce the change

Click on link in readme

## Checklist

Not needed

## Additional Notes

Minor fix using github website
