### PR TITLE
Configure pre-commit (ruff + hygiene + pydoclint) — revive #69 on current main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  # Ruff is already the project's linter/formatter (see [tool.ruff] in
+  # pyproject.toml and .github/workflows/ci.yml). These hooks mirror CI's
+  # `ruff check .` and `ruff format --check .` so violations are caught locally.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.20
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  # pydoclint checks that each docstring's Parameters/Returns/Raises match the
+  # signature — something ruff does not do. Config in [tool.pydoclint].
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 0.8.3
+    hooks:
+      - id: pydoclint
+        args: ['--config=pyproject.toml']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,8 @@ select = ["E", "F", "W", "I"]
 "*/__init__.py" = ["F401"]
 "tests/*.py" = ["E402"]
 
+[tool.pydoclint]
+style = 'numpy'
+allow-init-docstring = true
+quiet = true
+


### PR DESCRIPTION
## Summary

Revives #69 ("Configure linter") on current `main`, aligned with the repo's move
to **ruff**. #69 predates the ruff adoption and proposed **autopep8**, which now
conflicts with the existing `[tool.ruff]` config and the `ruff check .` /
`ruff format --check .` steps in `.github/workflows/ci.yml`. This swaps autopep8
for ruff so **pre-commit mirrors CI**, and keeps #69's docstring linting.

Adds `.pre-commit-config.yaml`:
- **pre-commit-hooks**: `check-yaml`, `check-toml`, `end-of-file-fixer`, `trailing-whitespace`
- **ruff-pre-commit**: `ruff` (lint, `--fix`) + `ruff-format` — mirror CI, using the existing `[tool.ruff]`
- **pydoclint** (from #69): docstring `Parameters`/`Returns`/`Raises` ↔ signature checking (ruff doesn't do this), configured via the new `[tool.pydoclint]` block in `pyproject.toml`

## Notes
- The codebase already passes `ruff check` and `ruff format --check` (verified), so the ruff hooks are green.
- pydoclint is **not** run in CI; the first `pre-commit run --all-files` will surface pre-existing docstring/signature mismatches, which can be cleaned incrementally.
- The `ruff-pre-commit` rev is pinned to `v0.15.20` (matching the installed ruff); keep it in sync with `pre-commit autoupdate`.

Supersedes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)