### PR TITLE
Time decay-product light from the decay vertex (ν_τ second-bang timing)

### DIFF
--- a/prometheus/injection/injection/LI_injection.py
+++ b/prometheus/injection/injection/LI_injection.py
@@ -109,6 +109,7 @@ def injection_event_from_LI(injection: h5.Group, idx: int) -> LIInjectionEvent:
             ),
             None,
             initial_state,
+            time=0.0,  # interaction-vertex particle starts at t=0
         )
         final_states.append(final_state)
     interaction = INTERACTION_CONVERTER[

--- a/prometheus/injection/injection/genie_injection.py
+++ b/prometheus/injection/injection/genie_injection.py
@@ -84,8 +84,10 @@ def _decay_pi0(
     if p_mag < 1e-9 or energy <= _M_PI0:
         dir0 = np.array([0.0, 0.0, 1.0])
         return [
-            PropagatableParticle(22, energy / 2.0, position.copy(), dir0.copy(), None, parent),
-            PropagatableParticle(22, energy / 2.0, position.copy(), -dir0, None, parent),
+            PropagatableParticle(
+                22, energy / 2.0, position.copy(), dir0.copy(), None, parent, time=0.0
+            ),
+            PropagatableParticle(22, energy / 2.0, position.copy(), -dir0, None, parent, time=0.0),
         ]
 
     # Boost parameters.
@@ -124,8 +126,8 @@ def _decay_pi0(
     dir2 /= np.linalg.norm(dir2)
 
     return [
-        PropagatableParticle(22, e1, position.copy(), dir1, None, parent),
-        PropagatableParticle(22, e2, position.copy(), dir2, None, parent),
+        PropagatableParticle(22, e1, position.copy(), dir1, None, parent, time=0.0),
+        PropagatableParticle(22, e2, position.copy(), dir2, None, parent, time=0.0),
     ]
 
 
@@ -243,6 +245,7 @@ def injection_from_genie_output(
                         direction,
                         None,
                         initial_state,
+                        time=0.0,  # interaction-vertex particle starts at t=0
                     )
                 )
 

--- a/prometheus/injection/injection/prometheus_injection.py
+++ b/prometheus/injection/injection/prometheus_injection.py
@@ -59,6 +59,7 @@ def prometheus_inj_to_li_injection_event(truth: ak.Record) -> LIInjectionEvent:
                 ]
             ),
             initial_state,
+            time=0.0,  # interaction-vertex particle starts at t=0
         )
         final_states.append(final_state)
     interaction = Interactions(truth["interaction"])

--- a/prometheus/particle/particle.py
+++ b/prometheus/particle/particle.py
@@ -65,6 +65,12 @@ class PropagatableParticle(Particle):
     ----------
     parent : Particle
         Particle which created this particle.
+    time : float
+        Time in ns at which this particle starts, relative to the primary
+        interaction vertex. 0.0 for interaction-vertex particles; the parent's
+        flight time to the decay vertex for decay products. Required (no
+        default) so that every propagated particle must state its start time —
+        a silently-defaulted time is the Issue #4 bug class.
     children : list of Particle
         Particles that this one spawned.
     losses : list
@@ -74,6 +80,7 @@ class PropagatableParticle(Particle):
     """
 
     parent: Particle
+    time: float
     children: List[Particle] = field(default_factory=list)
     losses: List = field(default_factory=list)
     hits: List = field(default_factory=list)

--- a/prometheus/particle/particle_from_proposal.py
+++ b/prometheus/particle/particle_from_proposal.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..utils.units import MeV_to_GeV, cm_to_m
+from ..utils.units import MeV_to_GeV, cm_to_m, s_to_ns
 from .particle import PropagatableParticle
 
 
@@ -34,5 +34,8 @@ def particle_from_proposal(
     direction = np.array(
         [pp_particle.direction.x, pp_particle.direction.y, pp_particle.direction.z]
     )
-    child = PropagatableParticle(pdg_code, e, position, direction, None, parent)
+    # PROPOSAL times are in seconds, relative to the propagation start (the
+    # parent's own start), so this is the parent's flight time to this vertex.
+    time = pp_particle.time * s_to_ns
+    child = PropagatableParticle(pdg_code, e, position, direction, None, parent, time=time)
     return child

--- a/prometheus/photon_propagation/olympus_photon_propagator.py
+++ b/prometheus/photon_propagation/olympus_photon_propagator.py
@@ -138,7 +138,7 @@ class OlympusPhotonPropagator(PhotonPropagator):
         )
 
         injection_event = {
-            "time": 0.0,
+            "time": particle.time,
             "theta": particle.theta,
             "phi": particle.phi,
             "pos": particle.position,

--- a/prometheus/utils/write_to_f2k.py
+++ b/prometheus/utils/write_to_f2k.py
@@ -32,7 +32,8 @@ def serialize_loss(loss, parent, output_f2k):
     loss : Loss
         Energy loss to serialize.
     parent : Particle
-        Parent particle that produced the loss; its direction is used.
+        Parent particle that produced the loss; its direction and start
+        time are used.
     output_f2k : file-like object
         Open file to write to.
     """
@@ -42,7 +43,10 @@ def serialize_loss(loss, parent, output_f2k):
     phi = np.arctan2(parent.direction[1], parent.direction[0])
     c = SpeedOfLight
     c /= s_to_ns
-    dt = d / c
+    # Offset by the parent's start time so decay-product light is timed from the
+    # decay vertex (reached at ~L_decay/c), not from t=0. The primary has
+    # time=0, leaving its own losses unchanged.
+    dt = parent.time + d / c
     line = (
         f"TR 0 {0} {loss} {offpos[0]} {offpos[1]} {offpos[2] + PPC_MAGIC_Z}"
         f" {theta} {phi} 0 {loss.e} {dt} \n"

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -24,7 +24,7 @@ def _make_propagatable(pdg=13, e=1e3, pos=None, direction=None, idx=0, parent=No
         pos = np.array([0.0, 0.0, 0.0])
     if direction is None:
         direction = np.array([0.0, 0.0, 1.0])
-    return PropagatableParticle(pdg, e, pos, direction, idx, parent)
+    return PropagatableParticle(pdg, e, pos, direction, idx, parent, time=0.0)
 
 
 class TestParticle:

--- a/tests/test_decay_time.py
+++ b/tests/test_decay_time.py
@@ -1,0 +1,94 @@
+"""Issue #4: decay-product light must be timed from the decay vertex.
+
+A daughter particle starts at time ``L_decay / c`` (the parent's flight time to
+the decay vertex), so its loss/hit times must carry that offset instead of
+restarting the clock at 0. These tests need no PPC binary/GPU.
+"""
+
+import numpy as np
+import pytest
+
+from prometheus.lepton_propagation import Loss
+from prometheus.particle import PropagatableParticle, particle_from_proposal
+from prometheus.utils import serialize_to_f2k
+from prometheus.utils.units import SpeedOfLight, s_to_ns
+
+_C_M_PER_NS = SpeedOfLight / s_to_ns  # m/ns
+_DIR_Z = np.array([0.0, 0.0, 1.0])
+
+
+def _tr_times(path):
+    return [float(ln.split()[11]) for ln in path.read_text().splitlines() if ln.startswith("TR")]
+
+
+def _particle(time=0.0, pdg=15):
+    return PropagatableParticle(pdg, 1e3, np.zeros(3), _DIR_Z, 0, None, time=time)
+
+
+class TestParticleTimeField:
+    def test_time_is_required(self):
+        # `time` has no default: omitting it must fail loud, not silently
+        # restart the clock at 0 (the Issue #4 bug class).
+        with pytest.raises(TypeError):
+            PropagatableParticle(15, 1e3, np.zeros(3), _DIR_Z, 0, None)
+
+    def test_time_is_stored(self):
+        assert _particle(time=1633.0).time == pytest.approx(1633.0)
+
+
+class TestLossTiming:
+    def test_primary_loss_timed_from_zero(self, tmp_path):
+        d = 300.0
+        p = _particle(time=0.0)
+        p.losses.append(Loss(-2000001006, 500.0, np.array([0.0, 0.0, d])))
+        out = tmp_path / "primary.f2k"
+        serialize_to_f2k(p, str(out))
+        assert _tr_times(out)[0] == pytest.approx(d / _C_M_PER_NS)
+
+    def test_daughter_loss_includes_flight_offset(self, tmp_path):
+        d = 300.0
+        offset = 1633.0  # ns, ~490 m tau flight
+        p = _particle(time=offset)
+        p.losses.append(Loss(-2000001006, 500.0, np.array([0.0, 0.0, d])))
+        out = tmp_path / "daughter.f2k"
+        serialize_to_f2k(p, str(out))
+        assert _tr_times(out)[0] == pytest.approx(offset + d / _C_M_PER_NS)
+
+    def test_child_serialized_with_its_own_time(self, tmp_path):
+        # serialize_to_f2k also writes the parent's children; each child's loss
+        # must be timed from that child's start time.
+        offset = 1633.0
+        parent = _particle(time=0.0)
+        child = PropagatableParticle(11, 500.0, np.zeros(3), _DIR_Z, 0, parent, time=offset)
+        child.losses.append(Loss(-2000001006, 500.0, np.array([0.0, 0.0, 150.0])))
+        parent.children.append(child)
+        out = tmp_path / "family.f2k"
+        serialize_to_f2k(parent, str(out))
+        assert _tr_times(out)[0] == pytest.approx(offset + 150.0 / _C_M_PER_NS)
+
+
+class _V:
+    def __init__(self, x, y, z):
+        self.x, self.y, self.z = x, y, z
+
+
+class _PPParticle:
+    """Duck-typed PROPOSAL particle (energy in MeV, position in cm, time in s)."""
+
+    type = 11
+    energy = 500_000.0
+    position = _V(0.0, 0.0, 49000.0)  # 490 m
+    direction = _V(0.0, 0.0, 1.0)
+    time = 1.634e-6  # s
+
+
+class TestParticleFromProposal:
+    def test_time_converted_seconds_to_ns(self):
+        child = particle_from_proposal(_PPParticle(), np.zeros(3), parent=_particle())
+        assert child.time == pytest.approx(_PPParticle.time * s_to_ns)
+
+    def test_zero_time_stays_zero(self):
+        pp = _PPParticle()
+        pp.time = 0.0
+        child = particle_from_proposal(pp, np.zeros(3), parent=_particle())
+        assert child.time == 0.0


### PR DESCRIPTION
## Summary

Fixes #102.

Decay-product particles were simulated as fresh `t = 0` events at the decay vertex — the parent's proper flight time to that vertex was never carried over. For a τ, the second-bang photon times were therefore too early by ~`L_decay / c` (~1.6 µs at 490 m for a 10 PeV τ), corrupting the double-bang **time separation**. Affects both the PPC and olympus propagators.

## Changes
- **`particle.py`** — required `time` field on `PropagatableParticle` (start time [ns] relative to the interaction vertex).
- **`particle_from_proposal.py`** — set the daughter's `time` from `pp_particle.time` (s → ns) = the parent's flight time to the decay vertex.
- **`write_to_f2k.py`** — `serialize_loss` offsets by the parent's start time (`dt = parent.time + d/c`); the primary has `time=0`, so its own losses are unchanged.
- **`olympus_photon_propagator.py`** — `injection_event["time"] = particle.time` instead of hardcoded `0.0`.
- **injection** (`LI_/genie_/prometheus_injection.py`) — interaction-vertex particles pass `time=0.0`.
- **`tests/test_decay_time.py`** — PPC-free tests: `time` is required, stored, and the flight-time offset is applied.

## Verification
- `ruff check .` and `ruff format --check .` pass.
- `pytest tests/test_decay_time.py` → 7 passed.

Port of the fix already merged on the `pavelzhelnin/prometheus` `Pavel-Tau` fork; touches only shared core files and applies cleanly to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)