### PR TITLE
Raise on nonzero PPC exit instead of silently reporting no hits

### DIFF
--- a/prometheus/photon_propagation/ppc_photon_propagator.py
+++ b/prometheus/photon_propagation/ppc_photon_propagator.py
@@ -74,8 +74,9 @@ def ppc_sim(particle: Particle, det: Detector, lp: LeptonPropagator, ppc_config:
         f"{ppc_config['paths']['ppc_exe']} {ppc_config['simulation']['device']}"
         f" < {f2k_tmpfile} > {ppc_tmpfile}"
     )
-    if ppc_config["simulation"]["supress_output"]:
-        command += " 2>/dev/null"
+    # NOTE: stderr is intentionally NOT redirected to /dev/null here. It is
+    # captured in Python below so a nonzero exit (bad ppc_exe path, missing
+    # tables, etc.) is raised instead of silently looking like "no photon hits".
 
     if not should_propagate(particle):
         return
@@ -84,13 +85,21 @@ def ppc_sim(particle: Particle, det: Detector, lp: LeptonPropagator, ppc_config:
     tenv = os.environ.copy()
     tenv["PPCTABLESDIR"] = ppc_config["paths"]["ppc_tmpdir"]
 
-    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, env=tenv)
-    process.wait()
-    try:
-        rc = process.returncode
-        subprocess_statuses.append({"cmd": command, "returncode": rc})
-    except Exception:
-        pass
+    process = subprocess.Popen(
+        command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=tenv
+    )
+    # communicate() (not wait()) so the captured stderr pipe can't deadlock.
+    _, stderr_data = process.communicate()
+    rc = process.returncode
+    subprocess_statuses.append({"cmd": command, "returncode": rc})
+    stderr_text = (stderr_data or b"").decode("utf-8", "replace")
+    if rc != 0:
+        logger.error(
+            "PPC exited with code %d for command %r\nstderr:\n%s", rc, command, stderr_text
+        )
+        raise RuntimeError(f"PPC failed with exit code {rc}; see logged stderr")
+    if stderr_text and not ppc_config["simulation"]["supress_output"]:
+        logger.info("PPC stderr:\n%s", stderr_text)
     particle.hits = parse_ppc(ppc_tmpfile)
     for f in [geo_tmpfile, f2k_tmpfile, ppc_tmpfile]:
         os.remove(f)

--- a/tests/test_ppc_stderr_raise.py
+++ b/tests/test_ppc_stderr_raise.py
@@ -1,0 +1,84 @@
+"""ppc_sim must fail loudly when the PPC subprocess exits nonzero.
+
+Previously stderr was redirected to /dev/null and the return code was ignored,
+so a bad exe path / missing tables / crash looked identical to "no photon hits".
+These tests drive ppc_sim to the subprocess call with a fake Popen (no PPC
+binary, no GPU) and assert the exit code is now honored.
+"""
+
+import logging
+
+import numpy as np
+import pytest
+
+import prometheus.photon_propagation.ppc_photon_propagator as ppc_mod
+from prometheus.particle import PropagatableParticle
+
+
+class _FakeDetector:
+    """Minimal stand-in exposing only what ppc_sim reads before the subprocess."""
+
+    offset = np.zeros(3)
+    outer_radius = 100.0  # r_inice = outer_radius + 1000 = 1100 m
+    modules = ()  # -> serial_nos == []
+
+    def to_f2k(self, path, serial_nos=None):
+        pass
+
+
+class _FakeProc:
+    """Stand-in for subprocess.Popen's return value."""
+
+    def __init__(self, returncode, stderr=b""):
+        self.returncode = returncode
+        self._stderr = stderr
+
+    def communicate(self):
+        return b"", self._stderr
+
+
+def _config():
+    return {
+        "paths": {
+            "ppc_tmpdir": "/tmp",
+            "ppc_tmpfile": "ppc",
+            "f2k_tmpfile": "f2k",
+            "ppc_exe": "ppc",
+        },
+        "simulation": {"device": "cpu", "supress_output": False},
+    }
+
+
+def _drive(monkeypatch, returncode, stderr=b""):
+    """Run ppc_sim up to and through the (faked) PPC subprocess call."""
+    monkeypatch.setattr(ppc_mod, "should_propagate", lambda p: True)
+    monkeypatch.setattr(ppc_mod, "serialize_to_f2k", lambda *a, **k: None)
+    monkeypatch.setattr(ppc_mod.os, "remove", lambda *a, **k: None)
+    monkeypatch.setattr(ppc_mod, "parse_ppc", lambda f: ["HIT"])
+    monkeypatch.setattr(ppc_mod.subprocess, "Popen", lambda *a, **k: _FakeProc(returncode, stderr))
+    # Hadron (2212): lp=None is safe; deposits a loss then reaches the subprocess.
+    particle = PropagatableParticle(
+        2212, 1000.0, np.zeros(3), np.array([0.0, 0.0, 1.0]), 0, None, 0.0
+    )
+    ppc_mod.ppc_sim(particle, _FakeDetector(), None, _config())
+    return particle
+
+
+def test_nonzero_exit_raises_with_stderr(monkeypatch, caplog):
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="exit code 3"):
+            _drive(monkeypatch, returncode=3, stderr=b"PPC: cannot open tables\n")
+    # The real stderr is surfaced in the logs, not swallowed.
+    assert "cannot open tables" in caplog.text
+
+
+def test_zero_exit_does_not_raise_and_parses_hits(monkeypatch):
+    particle = _drive(monkeypatch, returncode=0, stderr=b"")
+    assert particle.hits == ["HIT"]
+
+
+def test_records_status_in_subprocess_statuses(monkeypatch):
+    before = len(ppc_mod.subprocess_statuses)
+    _drive(monkeypatch, returncode=0, stderr=b"")
+    assert ppc_mod.subprocess_statuses[-1]["returncode"] == 0
+    assert len(ppc_mod.subprocess_statuses) == before + 1


### PR DESCRIPTION
## What

`ppc_sim` (`prometheus/photon_propagation/ppc_photon_propagator.py`) hid PPC failures two ways:

1. Under `supress_output` it redirected PPC's stderr to `/dev/null`.
2. It called `process.wait()` and recorded the return code in `subprocess_statuses` but **never checked it**.

So a bad `ppc_exe` path, missing tables, or a crash produced an empty/partial output file that `parse_ppc` turned into **"no photon hits"** — indistinguishable from a legitimate no-light event.

This PR:
- captures stderr via `communicate()` (avoiding a pipe deadlock),
- always records the return code, and
- **raises `RuntimeError`** with the logged stderr on a nonzero exit.

`supress_output` now only gates logging stderr on a *successful* run; failures are always logged and raised regardless.

## Tests

Adds `tests/test_ppc_stderr_raise.py` (no PPC binary/GPU needed) driving `ppc_sim` to a faked subprocess:
- nonzero exit → raises `RuntimeError` and surfaces stderr in the logs;
- zero exit → parses hits and does not raise;
- return code is recorded in `subprocess_statuses`.

Verified the failure test fails if the `raise` is removed, and the sibling `test_ppc_neutral_hadron.py` still passes alongside.

## Provenance

Extracted by hand from Pavel-Tau commit `a7f659c` (only the subprocess/stderr hunk; the multi-PMT output, `dx.dat`/`cx.dat` staging, and `PROM_PMT_DIAG` diagnostics in that commit are intentionally left out for their respective tracks). Part of the series of small branches upstreaming discrete fixes from Pavel-Tau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)