### PR TITLE
Fix zero photon yield from continuous PROPOSAL losses in the PPC path

### DIFF
--- a/prometheus/lepton_propagation/new_proposal_lepton_propagator.py
+++ b/prometheus/lepton_propagation/new_proposal_lepton_propagator.py
@@ -290,20 +290,18 @@ def new_proposal_losses(
     init_state = init_pp_particle(particle, coordinate_shift)
     propagation_length = np.linalg.norm(particle.position) + padding
     secondarys = prop.propagate(init_state, propagation_length * m_to_cm)
-    continuous_loss_sum = 0
     for loss in secondarys.stochastic_losses():
         loss_energy = loss.energy * MeV_to_GeV
-        if loss.type == 1000000008:
-            continuous_loss_sum += loss_energy
-        else:
-            pos = (
-                np.array([loss.position.x, loss.position.y, loss.position.z]) * cm_to_m
-                - coordinate_shift
-            )
-            # TODO more this to the serialization function. DTaSD
-            if np.linalg.norm(pos - detector_center) <= r_inice:
-                particle.losses.append(Loss(loss.type, loss_energy, pos))
-    # continuous_loss_sum = np.sum(secondarys.continuous_losses()) * MeV_to_GeV
+        pos = (
+            np.array([loss.position.x, loss.position.y, loss.position.z]) * cm_to_m
+            - coordinate_shift
+        )
+        # TODO more this to the serialization function. DTaSD
+        if np.linalg.norm(pos - detector_center) <= r_inice:
+            particle.losses.append(Loss(loss.type, loss_energy, pos))
+    # PROPOSAL reports continuous (below-cut) losses separately from
+    # stochastic_losses(); their total is smeared along the track below.
+    continuous_loss_sum = sum(loss.energy for loss in secondarys.continuous_losses()) * MeV_to_GeV
     total_dist = secondarys.track_propagated_distances()[-1] * cm_to_m
     # TODO: Add this to config
     cont_resolution = 1.0

--- a/tests/test_continuous_losses.py
+++ b/tests/test_continuous_losses.py
@@ -1,0 +1,161 @@
+"""Unit tests for continuous-energy-loss handling in new_proposal_losses.
+
+PROPOSAL v7's ``Secondaries.stochastic_losses()`` never contains
+ContinuousEnergyLoss (type 1000000008) entries; continuous losses are only
+available via ``Secondaries.continuous_losses()``. These tests fake the
+PROPOSAL objects to check that the continuous energy actually ends up in the
+1000000008 point losses smeared along the track.
+"""
+
+import numpy as np
+import pytest
+
+from prometheus.lepton_propagation.new_proposal_lepton_propagator import (
+    new_proposal_losses,
+)
+
+CONTINUOUS_TYPE = 1000000008
+EPAIR_TYPE = 1000000004
+
+
+class FakeVector:
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+class FakeStochasticLoss:
+    def __init__(self, loss_type, energy_mev, position_cm):
+        self.type = loss_type
+        self.energy = energy_mev
+        self.position = FakeVector(*position_cm)
+
+
+class FakeContinuousLoss:
+    def __init__(self, energy_mev):
+        self.energy = energy_mev
+
+
+class FakeSecondaries:
+    def __init__(self, stochastic, continuous, distances_cm):
+        self._stochastic = stochastic
+        self._continuous = continuous
+        self._distances_cm = distances_cm
+
+    def stochastic_losses(self):
+        return self._stochastic
+
+    def continuous_losses(self):
+        return self._continuous
+
+    def decay_products(self):
+        return []
+
+    def track_propagated_distances(self):
+        return self._distances_cm
+
+
+class FakePropagator:
+    def __init__(self, secondaries):
+        self._secondaries = secondaries
+
+    def propagate(self, init_state, distance_cm):
+        return self._secondaries
+
+
+class FakeParticle:
+    def __init__(self):
+        self.position = np.array([0.0, 0.0, 0.0])
+        self.direction = np.array([0.0, 0.0, 1.0])
+        self.e = 1e3
+        self.time = 0.0
+        self.losses = []
+        self.children = []
+
+
+COORDINATE_SHIFT = np.array([0.0, 0.0, 100.0])
+DETECTOR_CENTER = np.array([0.0, 0.0, 0.0])
+R_INICE = 500.0
+
+
+def run_losses(secondaries):
+    particle = FakeParticle()
+    new_proposal_losses(
+        FakePropagator(secondaries),
+        particle,
+        padding=100.0,
+        r_inice=R_INICE,
+        detector_center=DETECTOR_CENTER,
+        coordinate_shift=COORDINATE_SHIFT,
+    )
+    return particle
+
+
+def prometheus_to_proposal_cm(position_m):
+    return (np.asarray(position_m) + COORDINATE_SHIFT) * 1e2
+
+
+def test_continuous_losses_smeared_along_track():
+    secondaries = FakeSecondaries(
+        stochastic=[],
+        continuous=[FakeContinuousLoss(500.0), FakeContinuousLoss(1500.0)],
+        distances_cm=[100.0 * 1e2],
+    )
+    particle = run_losses(secondaries)
+
+    deltas = [loss for loss in particle.losses if loss.int_type == CONTINUOUS_TYPE]
+    assert len(deltas) == 100
+    assert sum(loss.e for loss in deltas) == pytest.approx(2.0)
+    assert all(loss.e == pytest.approx(0.02) for loss in deltas)
+    np.testing.assert_allclose(deltas[0].position, particle.position)
+    np.testing.assert_allclose(deltas[1].position, particle.position + particle.direction)
+
+
+def test_continuous_sum_independent_of_stochastic_losses():
+    # PROPOSAL never puts type-1000000008 entries in stochastic_losses(), so
+    # the continuous energy must come from continuous_losses() alone.
+    secondaries = FakeSecondaries(
+        stochastic=[
+            FakeStochasticLoss(EPAIR_TYPE, 3000.0, prometheus_to_proposal_cm([0.0, 0.0, 10.0]))
+        ],
+        continuous=[FakeContinuousLoss(2000.0)],
+        distances_cm=[100.0 * 1e2],
+    )
+    assert not any(loss.type == CONTINUOUS_TYPE for loss in secondaries.stochastic_losses())
+    particle = run_losses(secondaries)
+
+    continuous_total = sum(loss.e for loss in particle.losses if loss.int_type == CONTINUOUS_TYPE)
+    assert continuous_total == pytest.approx(2.0)
+    assert continuous_total > 0.0
+
+
+def test_stochastic_losses_converted_and_filtered_by_r_inice():
+    inside = FakeStochasticLoss(EPAIR_TYPE, 3000.0, prometheus_to_proposal_cm([0.0, 0.0, 10.0]))
+    outside = FakeStochasticLoss(
+        EPAIR_TYPE, 5000.0, prometheus_to_proposal_cm([0.0, 0.0, R_INICE + 1.0])
+    )
+    secondaries = FakeSecondaries(
+        stochastic=[inside, outside],
+        continuous=[],
+        distances_cm=[100.0 * 1e2],
+    )
+    particle = run_losses(secondaries)
+
+    stochastic = [loss for loss in particle.losses if loss.int_type == EPAIR_TYPE]
+    assert len(stochastic) == 1
+    assert stochastic[0].e == pytest.approx(3.0)
+    np.testing.assert_allclose(stochastic[0].position, [0.0, 0.0, 10.0], atol=1e-9)
+
+
+def test_zero_length_track_fallback():
+    secondaries = FakeSecondaries(
+        stochastic=[],
+        continuous=[FakeContinuousLoss(2000.0)],
+        distances_cm=[0.0],
+    )
+    particle = run_losses(secondaries)
+
+    deltas = [loss for loss in particle.losses if loss.int_type == CONTINUOUS_TYPE]
+    assert len(deltas) == 2
+    assert sum(loss.e for loss in deltas) == pytest.approx(1e-3)


### PR DESCRIPTION
Fixes #47.

## The bug

`new_proposal_losses` accumulated continuous energy losses by scanning `secondarys.stochastic_losses()` for entries with type 1000000008 (ContinuousEnergyLoss). PROPOSAL v7's `GetStochasticLosses()` explicitly filters ContinuousEnergyLoss out of its return value, so that branch has never fired in any PROPOSAL v7 release: `continuous_loss_sum` was always 0 and every 1 m-spaced delta loss written along the track carried 0 GeV. All light below the stochastic threshold (bare-muon Cherenkov, delta rays, every sub-cut loss) was missing from the PPC path, as reported in #47 and independently diagnosed by @JakParkinson in #45.

## The fix

The minimal interim fix proposed in the #47 discussion: sum `secondarys.continuous_losses()` (the API the olympus path already uses at `event_generation.py:298`), convert MeV to GeV, and keep the existing 1 m redistribution downstream unchanged. The dead type check is removed from the stochastic loop since it can never match.

This restores the missing energy budget with no interface changes and stays consistent at any `(ecut, vcut)` combination and for every propagator. The `amu-` treatment from #45 remains the better long-term representation for the PPC path; see the #47 discussion for what it needs before it can be the default (a fixed 0.5 GeV threshold, i.e. `vcut` effectively disabled on the PPC path to avoid double counting below 5 GeV, plus per-segment directions and lengths carried through serialization).

## Measured impact

100 isotropic mu- at 1 TeV in ARCA seawater (PREM_arca, PROPOSAL 7.6.2, `ecut = 0.5 GeV`, `vcut = 0.1`): the fixed code yields a per-event continuous loss of median 602 GeV, mean 574 GeV (range 94 to 751 GeV). A seeded A/B control run of the same script against pre-fix `main` simulates the identical 100 muon tracks (event directions equal, stochastic sums bit-identical event-by-event) and puts every event at exactly 0 continuous loss, so the accumulator is the only difference. In other words, at 1 TeV roughly 57% of the deposited muon energy silently produced no light.

![Per-event continuous energy loss for 100 isotropic 1 TeV muons in ARCA seawater: pre-fix code all at zero, fixed code peaking near 650 GeV](https://github.com/sevmag/prometheus/releases/download/pr-assets/continuous_losses.png)

## Changes

- `prometheus/lepton_propagation/new_proposal_lepton_propagator.py`: continuous sum from `continuous_losses()`; dead branch removed; smearing machinery untouched.
- `tests/test_continuous_losses.py` (new): 4 unit tests driving `new_proposal_losses` with fake PROPOSAL objects, covering the nonzero continuous smearing, MeV to GeV conversion and `r_inice` filtering of stochastics, independence from `stochastic_losses()` contents, and the zero-length-track fallback. The two continuous-loss tests fail against the old code (`Obtained: 0.0, Expected: 2.0`).

Tests: new file 4 passed; broader suite (excluding the slow e2e/smoke sets) 262 passed, 0 failures; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
