### PR TITLE
Install CUDA-enabled jax in the GPU image

### DIFF
--- a/container/Dockerfile.gpu
+++ b/container/Dockerfile.gpu
@@ -15,6 +15,12 @@
 #   - PPC is compiled with `make gpu` (nvcc) instead of `make cpu` (g++)
 #   - The GPU PPC_CUDA variant is also compiled
 #   - PPC_CUDA env var points at the CUDA binary
+#   - jax is installed with the cuda12 extra, so the olympus propagator runs
+#     on the GPU rather than falling back to the CPU
+#
+# Note that the two GPU paths are independent. PPC_CUDA covers ice, and is
+# what SM_ARCH below applies to. Water goes through olympus, which is JAX, and
+# is unaffected by SM_ARCH because the CUDA kernels are compiled at runtime.
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Stage 1: system packages + micromamba environment
@@ -61,6 +67,18 @@ FROM base AS proposal
 
 COPY requirements.txt /tmp/requirements.txt
 RUN /opt/conda/envs/prometheus/bin/pip install --no-cache-dir -r /tmp/requirements.txt
+
+# requirements.txt is shared with the CPU image, so the jax it pins is the
+# CPU-only wheel. Without this step JAX silently falls back to the CPU inside
+# the GPU image ("a CUDA-enabled jaxlib is not installed"), which means the
+# olympus photon propagator, and therefore every water simulation, runs on the
+# CPU on a machine that was asked for a GPU.
+#
+# The cuda12 extra is the one that ships its own CUDA libraries as pip wheels.
+# cuda12-local, which links against the system toolkit, is not usable here:
+# the nvidia/cuda:12.3.2-devel base provides nvcc but no cuDNN, which JAX
+# needs. Only the host driver has to be new enough for CUDA 12.
+RUN /opt/conda/envs/prometheus/bin/pip install --no-cache-dir "jax[cuda12]"
 
 COPY container/build_proposal_tables.py /tmp/build_proposal_tables.py
 RUN LD_LIBRARY_PATH=/opt/conda/envs/prometheus/lib \


### PR DESCRIPTION
The GPU image installed the shared `requirements.txt` and nothing else, so it got the CPU-only jax wheel. JAX then fell back at runtime with "a CUDA-enabled jaxlib is not installed". The olympus photon propagator ran on the CPU inside an image built and published for GPUs.

`config_mims` selects olympus for water, so every water simulation in the GPU image was CPU bound. Only the ice path, through PPC_CUDA, used the device.

## Fix

One step after the requirements install in `container/Dockerfile.gpu`:

```dockerfile
RUN /opt/conda/envs/prometheus/bin/pip install --no-cache-dir "jax[cuda12]"
```

The CPU image shares `requirements.txt`, so this keeps it untouched.

`cuda12` rather than `cuda12-local`: the pip variant ships its own CUDA libraries including cuDNN 9, which the `nvidia/cuda:12.3.2-devel` base does not provide. `cuda12-local` links the system toolkit and would fail at runtime.

The pip wheels are CUDA 12.9 inside a CUDA 12.3 base. They are self-contained, so both coexist. The base toolkit is still what nvcc uses to build PPC_CUDA, and only the host driver needs to support CUDA 12.

## Cost

About 2.8 GB added to the image, mostly cuDNN (762 MiB) and cuBLAS (554 MiB).

## Verification

Not built. A CUDA image build needs a GPU host. What is checked is that the dependency set resolves and brings its own cuDNN:

```
jax==0.11.0, jaxlib==0.11.0, jax-cuda12-pjrt, jax-cuda12-plugin
nvidia-cudnn-cu12==9.24.0.43
nvidia-cublas / cusolver / cusparse / nccl / cufft
```

Please smoke test on real hardware before publishing an image from this, for example `python -c "import jax; print(jax.devices())"` showing a CUDA device.

## Related

Relevant to #116, which reports memory problems in a GPU container running a water simulation. That run was on the CPU. Once JAX uses the device, the XLA executable cache moves to GPU memory, so the memory picture there needs rechecking.

Container publishing should wait for this, so the next GPU tag is a real GPU image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
