### PR TITLE
Fix olympus hit keys and reject bad geo files

### DIFF
--- a/prometheus/detector/__init__.py
+++ b/prometheus/detector/__init__.py
@@ -1,4 +1,4 @@
-from .detector import Detector
+from .detector import Detector, GeometryError
 from .detector_factory import (
     detector_from_geo,
     make_grid,

--- a/prometheus/detector/detector.py
+++ b/prometheus/detector/detector.py
@@ -4,6 +4,7 @@
 # Deals with detector stuff
 from __future__ import annotations
 
+import warnings
 from typing import List, Tuple, Union
 
 import awkward as ak
@@ -29,6 +30,119 @@ class IncompatibleMACIDsError(Exception):
         super().__init__(self.message)
 
 
+class GeometryError(ValueError):
+    """Raised when a detector geometry is not usable.
+
+    The message lists every problem found so a geo file can be fixed in one
+    pass rather than one error at a time.
+    """
+
+    def __init__(self, problems: List[str], source: str = "detector geometry"):
+        self.problems = list(problems)
+        lines = "\n".join(f"  - {p}" for p in self.problems)
+        super().__init__(f"Invalid {source}:\n{lines}")
+
+
+# Modules on one string may drift in (x, y) by well under a metre in surveyed
+# geometries (IceCube: 0.6 m). Anything past this is a different string.
+STRING_XY_TOLERANCE_M = 5.0
+
+
+def _format_examples(items: List[str], limit: int = 5) -> str:
+    """Join up to ``limit`` example strings, noting how many were left out."""
+    shown = ", ".join(items[:limit])
+    if len(items) > limit:
+        shown += f", ... ({len(items) - limit} more)"
+    return shown
+
+
+def validate_modules(modules: List[Module]) -> None:
+    """Check that a list of modules describes a usable detector.
+
+    Errors are collected and raised together. Every ``(string_id, om_id)`` key
+    must be unique because hits are matched back to modules by key, and every
+    position must be finite. Negative IDs and strings whose modules spread
+    more than ``STRING_XY_TOLERANCE_M`` in (x, y) are legal but unusual, so they only warn.
+
+    Parameters
+    ----------
+    modules : list of Module
+        Modules to check.
+
+    Raises
+    ------
+    GeometryError
+        If the modules cannot form a valid detector.
+    """
+    problems = []
+    if len(modules) == 0:
+        raise GeometryError(["no modules"])
+
+    pos = np.array([m.pos for m in modules], dtype=float)
+    if pos.ndim != 2 or pos.shape[1] != 3:
+        problems.append(f"module positions must be (x, y, z); got shape {pos.shape}")
+    else:
+        bad = np.where(~np.isfinite(pos).all(axis=1))[0]
+        if len(bad):
+            problems.append(
+                f"{len(bad)} module(s) with non-finite position, e.g. module index "
+                f"{_format_examples([str(i) for i in bad])}"
+            )
+
+    # Duplicate keys. Explain them by the physical string they came from: the
+    # usual cause is one string ID reused for two strings at different (x, y).
+    seen = {}
+    dup_keys = []
+    for m in modules:
+        if m.key in seen:
+            dup_keys.append(m.key)
+        else:
+            seen[m.key] = m
+    if dup_keys:
+        problems.append(
+            f"{len(dup_keys)} duplicate (string_id, om_id) key(s), e.g. "
+            f"{_format_examples([str(k) for k in dup_keys])}"
+        )
+    strings = {}
+    for m in modules:
+        strings.setdefault(m.key[0], []).append(m)
+    reused = []
+    unaligned = []
+    for sid, mods in strings.items():
+        xy_all = np.array([m.pos[:2] for m in mods], dtype=float)
+        if np.ptp(xy_all, axis=0).max() > STRING_XY_TOLERANCE_M:
+            xy = np.unique(np.round(xy_all / STRING_XY_TOLERANCE_M) * STRING_XY_TOLERANCE_M, axis=0)
+            where = "; ".join(f"({x:g}, {y:g})" for x, y in xy[:3])
+            keys = {m.key for m in mods}
+            if len(keys) < len(mods):
+                reused.append(f"string {sid} at {where}")
+            else:
+                unaligned.append(f"string {sid} at {where}")
+    if reused:
+        problems.append(
+            f"{len(reused)} string ID(s) shared by modules at different (x, y), so two "
+            f"physical strings carry the same ID: {_format_examples(reused, 3)}"
+        )
+
+    if problems:
+        raise GeometryError(problems)
+
+    negative = sorted({m.key for m in modules if m.key[0] < 0 or m.key[1] < 0})
+    if negative:
+        warnings.warn(
+            f"{len(negative)} module(s) with a negative string or OM ID, e.g. "
+            f"{_format_examples([str(k) for k in negative])}. Prometheus accepts these "
+            "but downstream tools may not.",
+            stacklevel=3,
+        )
+    if unaligned:
+        warnings.warn(
+            f"{len(unaligned)} string ID(s) whose modules are not on one vertical line: "
+            f"{_format_examples(unaligned, 3)}",
+            stacklevel=3,
+        )
+
+
 class Detector(object):
     """Prometheus detector object."""
 
@@ -42,6 +156,7 @@ class Detector(object):
         medium : Medium or None
             Medium in which the detector is embedded.
         """
+        validate_modules(modules)
         self._modules = modules
         self._medium = medium
         self._offset = np.mean(np.array([m.pos for m in modules]), axis=0)

--- a/prometheus/detector/detector_factory.py
+++ b/prometheus/detector/detector_factory.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy
 
 from ..utils import iter_or_rep
-from .detector import Detector
+from .detector import Detector, GeometryError
 from .medium import Medium
 from .module import Module
 from .utils import random_serial
@@ -70,6 +70,72 @@ def read_medium(geofile) -> Union[Medium, None]:
     return getattr(Medium, medium_string)
 
 
+def read_geo_modules(geofile: str):
+    """Read the module block of a geofile, reporting every malformed line.
+
+    A module line is ``x y z string_id om_id`` separated by tabs. The first
+    three fields must be finite floats and the last two integers.
+
+    Parameters
+    ----------
+    geofile : str
+        Path to the geofile to read from.
+
+    Returns
+    -------
+    pos : list of np.ndarray
+        Module positions in m.
+    keys : list of tuple of int
+        ``(string_id, om_id)`` for each module.
+
+    Raises
+    ------
+    GeometryError
+        If the module header is missing, no modules are listed, or any line
+        cannot be parsed.
+    """
+    with open(geofile) as geo_in:
+        read_lines = geo_in.readlines()
+    header = [i for i, line in enumerate(read_lines) if line.strip() == "### Modules ###"]
+    if not header:
+        raise GeometryError(["missing '### Modules ###' header"], source=f"geo file {geofile}")
+
+    pos = []
+    keys = []
+    problems = []
+    for lineno, line in enumerate(read_lines[header[0] + 1 :], start=header[0] + 2):
+        if not line.strip():
+            continue
+        fields = line.strip("\n").split("\t")
+        if len(fields) != 5:
+            problems.append(
+                f"line {lineno}: expected 5 tab-separated fields "
+                f"(x y z string_id om_id), got {len(fields)}: {line.strip()!r}"
+            )
+            continue
+        try:
+            xyz = np.array([float(f) for f in fields[:3]])
+        except ValueError:
+            problems.append(f"line {lineno}: position is not numeric: {line.strip()!r}")
+            continue
+        if not np.isfinite(xyz).all():
+            problems.append(f"line {lineno}: position is not finite: {line.strip()!r}")
+            continue
+        try:
+            key = (int(fields[3]), int(fields[4]))
+        except ValueError:
+            problems.append(f"line {lineno}: string_id/om_id are not integers: {line.strip()!r}")
+            continue
+        pos.append(xyz)
+        keys.append(key)
+
+    if not problems and not pos:
+        problems.append("no modules listed after '### Modules ###'")
+    if problems:
+        raise GeometryError(problems, source=f"geo file {geofile}")
+    return pos, keys
+
+
 def detector_from_geo(geofile: str, efficiency: float = 0.2, noise_rate: float = 1) -> Detector:
     """Build a detector from a Prometheus geofile.
 
@@ -87,17 +153,8 @@ def detector_from_geo(geofile: str, efficiency: float = 0.2, noise_rate: float =
     detector : Detector
         Prometheus detector object.
     """
-    pos = []
-    keys = []
+    pos, keys = read_geo_modules(geofile)
     medium = read_medium(geofile)
-    with open(geofile) as geo_in:
-        read_lines = geo_in.readlines()
-        modules_i = read_lines.index("### Modules ###\n")
-
-        for line in read_lines[modules_i + 1 :]:
-            line = line.strip("\n").split("\t")
-            pos.append(np.array([float(line[0]), float(line[1]), float(line[2])]))
-            keys.append((int(line[3]), int(line[4])))
 
     sers = [random_serial() for _ in range(len(pos))]
 
@@ -108,7 +165,10 @@ def detector_from_geo(geofile: str, efficiency: float = 0.2, noise_rate: float =
         Module(p, k, efficiency=e, noise_rate=nr, serial_no=ser)
         for p, k, e, nr, ser in zip(pos, keys, efficiency, noise_rate, sers)
     ]
-    det = Detector(modules, medium)
+    try:
+        det = Detector(modules, medium)
+    except GeometryError as err:
+        raise GeometryError(err.problems, source=f"geo file {geofile}") from None
     return det
 
 

--- a/prometheus/photon_propagation/olympus_photon_propagator.py
+++ b/prometheus/photon_propagation/olympus_photon_propagator.py
@@ -50,6 +50,44 @@ _DEFAULT_FLOW_FILE = "photon_arrival_time_nflow_params.pickle"
 _DEFAULT_COUNTS_FILE = "photon_arrival_time_counts_params.pickle"
 
 
+def hits_from_olympus_result(detector: Detector, res_event) -> list:
+    """Convert per-module olympus photon times into Prometheus ``Hit`` objects.
+
+    Parameters
+    ----------
+    detector : Detector
+        Prometheus detector the photons were propagated through. Olympus
+        returns one entry per module, in ``detector.modules`` order.
+    res_event : sequence or None
+        Per-module sequences of photon arrival times in ns, or ``None`` when
+        the propagation produced no light at all.
+
+    Returns
+    -------
+    hits : list of Hit
+        Hits keyed by each module's real ``(string_id, om_id)`` so they can be
+        looked up on the detector during serialization.
+
+    Raises
+    ------
+    ValueError
+        If ``res_event`` does not hold exactly one entry per detector module.
+    """
+    if res_event is None:
+        return []
+    if len(res_event) != len(detector.modules):
+        raise ValueError(
+            f"Olympus returned {len(res_event)} module entries for a detector "
+            f"with {len(detector.modules)} modules"
+        )
+    hits = []
+    for mod, dom_hits in zip(detector.modules, res_event):
+        string_id, om_id = mod.key
+        for hit in dom_hits:
+            hits.append(Hit(string_id, om_id, float(hit), None, None, None, None, None))
+    return hits
+
+
 @register_propagator("olympus")
 class OlympusPhotonPropagator(PhotonPropagator):
     """Photon propagator that uses Olympus to propagate photons."""
@@ -179,22 +217,9 @@ class OlympusPhotonPropagator(PhotonPropagator):
                 max_distance=self.config["simulation"]["max_distance"],
             )
 
-        hits = []
         # generate_realistic_track returns (None, None) when PROPOSAL yields no
         # energy losses at all; treat that as an event with no hits.
-        if res_event is not None:
-            nstrings = len(set([mod.key[0] for mod in self.detector.modules]))
-            string_idx = 0
-            om_idx = 0
-            oms_per_string = len(self.detector.modules) / nstrings
-            for dom_hits in res_event:
-                if om_idx == oms_per_string:
-                    om_idx = 0
-                    string_idx += 1
-                for hit in dom_hits:
-                    hits.append(Hit(string_idx, om_idx, float(hit), None, None, None, None, None))
-                om_idx += 1
-        particle.hits = hits
+        particle.hits = hits_from_olympus_result(self.detector, res_event)
         for child in particle.children:
             if child.e < 1:
                 continue

--- a/tests/test_geo_validation.py
+++ b/tests/test_geo_validation.py
@@ -1,0 +1,127 @@
+"""Geometry validation: a bad geo file must fail loudly and say why.
+
+Every problem is reported in one ``GeometryError`` so the file can be fixed
+in a single pass. Duplicate ``(string_id, om_id)`` keys are the important
+case: hits are matched back to modules by key, so a duplicate silently sends
+light to the wrong module.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from prometheus.detector import Detector, GeometryError, Medium, Module, detector_from_geo
+
+HEADER = "### Metadata ###\nMedium:\twater\n### Modules ###\n"
+
+
+def _write_geo(tmp_path, rows, header=HEADER):
+    path = tmp_path / "test.geo"
+    body = "".join("\t".join(str(v) for v in row) + "\n" for row in rows)
+    path.write_text(header + body)
+    return str(path)
+
+
+def _string(sid, x, y, n=3, om0=0):
+    return [(x, y, 10.0 * i, sid, om0 + i) for i in range(n)]
+
+
+def test_good_file_loads_without_warnings(tmp_path):
+    path = _write_geo(tmp_path, _string(0, 0, 0) + _string(1, 50, 0))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        det = detector_from_geo(path)
+    assert det.n_modules == 6
+
+
+def test_survey_drift_within_tolerance_is_fine(tmp_path):
+    rows = [(0.0, 0.0, 0.0, 0, 0), (0.6, -0.4, 10.0, 0, 1)]
+    path = _write_geo(tmp_path, rows)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        detector_from_geo(path)
+
+
+def test_reused_string_id_reports_both_positions(tmp_path):
+    # Two physical strings at different (x, y) both labelled string 3.
+    path = _write_geo(tmp_path, _string(3, 0, 0) + _string(3, 50, 20))
+    with pytest.raises(GeometryError) as excinfo:
+        detector_from_geo(path)
+    msg = str(excinfo.value)
+    assert "test.geo" in msg
+    assert "3 duplicate (string_id, om_id) key(s)" in msg
+    assert "(3, 0)" in msg
+    assert "string 3 at (0, 0); (50, 20)" in msg
+
+
+def test_all_problems_reported_together(tmp_path):
+    rows = _string(0, 0, 0)
+    rows.append((1.0, 2.0))  # too few fields
+    rows.append(("a", 0.0, 0.0, 1, 0))  # non-numeric position
+    rows.append((0.0, 0.0, "nan", 1, 1))  # non-finite position
+    rows.append((0.0, 0.0, 0.0, 1, "x"))  # non-integer id
+    path = _write_geo(tmp_path, rows)
+    with pytest.raises(GeometryError) as excinfo:
+        detector_from_geo(path)
+    problems = excinfo.value.problems
+    assert len(problems) == 4
+    assert problems[0].startswith("line 7:") and "expected 5" in problems[0]
+    assert problems[1].startswith("line 8:") and "not numeric" in problems[1]
+    assert problems[2].startswith("line 9:") and "not finite" in problems[2]
+    assert problems[3].startswith("line 10:") and "not integers" in problems[3]
+
+
+def test_missing_modules_header(tmp_path):
+    path = _write_geo(tmp_path, _string(0, 0, 0), header="### Metadata ###\nMedium:\twater\n")
+    with pytest.raises(GeometryError, match="missing '### Modules ###'"):
+        detector_from_geo(path)
+
+
+def test_no_modules(tmp_path):
+    path = _write_geo(tmp_path, [])
+    with pytest.raises(GeometryError, match="no modules listed"):
+        detector_from_geo(path)
+
+
+def test_blank_lines_are_ignored(tmp_path):
+    path = _write_geo(tmp_path, _string(0, 0, 0))
+    with open(path, "a") as f:
+        f.write("\n\n")
+    assert detector_from_geo(path).n_modules == 3
+
+
+def test_negative_ids_warn_but_load(tmp_path):
+    path = _write_geo(tmp_path, _string(-1, 0, 0) + _string(1, 50, 0))
+    with pytest.warns(UserWarning, match="negative string or OM ID"):
+        det = detector_from_geo(path)
+    assert det.n_modules == 6
+
+
+def test_unaligned_string_warns(tmp_path):
+    rows = [(0.0, 0.0, 0.0, 0, 0), (30.0, 0.0, 10.0, 0, 1)]
+    path = _write_geo(tmp_path, rows)
+    with pytest.warns(UserWarning, match="not on one vertical line"):
+        detector_from_geo(path)
+
+
+class TestDetectorConstructor:
+    def test_duplicate_keys_rejected(self):
+        mods = [Module(np.array([0.0, 0.0, z]), (0, 0)) for z in (0.0, 10.0)]
+        with pytest.raises(GeometryError, match="duplicate"):
+            Detector(mods, Medium.WATER)
+
+    def test_add_with_overlapping_keys_rejected(self):
+        a = Detector([Module(np.array([0.0, 0.0, 0.0]), (0, 0))], Medium.WATER)
+        b = Detector([Module(np.array([50.0, 0.0, 0.0]), (0, 0))], Medium.WATER)
+        with pytest.raises(GeometryError, match="same ID"):
+            a + b
+
+    def test_non_finite_position_rejected(self):
+        mods = [Module(np.array([0.0, np.inf, 0.0]), (0, 0))]
+        with pytest.raises(GeometryError, match="non-finite"):
+            Detector(mods, Medium.WATER)
+
+    def test_empty_rejected(self):
+        with pytest.raises(GeometryError, match="no modules"):
+            Detector([], Medium.WATER)

--- a/tests/test_olympus_hit_keys.py
+++ b/tests/test_olympus_hit_keys.py
@@ -16,8 +16,8 @@ from prometheus.photon_propagation.olympus_photon_propagator import hits_from_ol
 
 
 def _detector(keys):
-    rng = np.random.default_rng(0)
-    modules = [Module(rng.normal(0, 100, 3), key) for key in keys]
+    # Place each string on its own vertical line so the geometry is valid.
+    modules = [Module(np.array([100.0 * s, 0.0, 10.0 * o]), (s, o)) for s, o in keys]
     return Detector(modules, Medium.WATER)
 
 

--- a/tests/test_olympus_hit_keys.py
+++ b/tests/test_olympus_hit_keys.py
@@ -1,0 +1,70 @@
+"""Olympus hits must carry the real module keys, not synthesized ones.
+
+The old conversion assumed every string had the same number of OMs, string
+IDs ran from 0 and OM IDs ran from 0 in file order. Any geo file that broke
+those assumptions produced hits whose keys were not in the detector, and
+serialization failed with ``ValueError: (s, o) is not in list``.
+"""
+
+import awkward as ak
+import numpy as np
+import pytest
+
+from prometheus.detector import Detector, Medium
+from prometheus.detector.module import Module
+from prometheus.photon_propagation.olympus_photon_propagator import hits_from_olympus_result
+
+
+def _detector(keys):
+    rng = np.random.default_rng(0)
+    modules = [Module(rng.normal(0, 100, 3), key) for key in keys]
+    return Detector(modules, Medium.WATER)
+
+
+def _one_hit_per_module(n_modules):
+    return ak.Array([[10.0 * i] for i in range(n_modules)])
+
+
+@pytest.mark.parametrize(
+    "keys",
+    [
+        # 1-based string and OM numbering
+        [(s, o) for s in range(1, 4) for o in range(1, 4)],
+        # uneven strings
+        [(0, o) for o in range(5)] + [(1, o) for o in range(2)],
+        # OM-major file order
+        [(s, o) for o in range(3) for s in range(2)],
+        # non-contiguous string IDs
+        [(s, o) for s in (3, 7, 42) for o in range(2)],
+    ],
+)
+def test_hits_use_real_module_keys(keys):
+    det = _detector(keys)
+    hits = hits_from_olympus_result(det, _one_hit_per_module(len(keys)))
+
+    assert [(h.string_id, h.om_id) for h in hits] == keys
+    # Every hit must resolve on the detector, as serialization requires.
+    for hit, mod in zip(hits, det.modules):
+        assert det[(hit.string_id, hit.om_id)] is mod
+    assert [h.time for h in hits] == [10.0 * i for i in range(len(keys))]
+
+
+def test_multiple_hits_and_empty_modules():
+    det = _detector([(0, 0), (0, 1), (1, 0)])
+    hits = hits_from_olympus_result(det, ak.Array([[1.0, 2.0], [], [3.0]]))
+    assert [(h.string_id, h.om_id, h.time) for h in hits] == [
+        (0, 0, 1.0),
+        (0, 0, 2.0),
+        (1, 0, 3.0),
+    ]
+
+
+def test_none_result_gives_no_hits():
+    det = _detector([(0, 0)])
+    assert hits_from_olympus_result(det, None) == []
+
+
+def test_module_count_mismatch_raises():
+    det = _detector([(0, 0), (0, 1)])
+    with pytest.raises(ValueError, match="module entries"):
+        hits_from_olympus_result(det, ak.Array([[1.0]]))


### PR DESCRIPTION
Two fixes for the `ValueError: (0, 38) is not in list` crash reported when running Olympus (GPU mode) on a custom geo file.

## 1. Olympus hits use the real module keys

The olympus propagator built hit keys by counting modules. It assumed every string has the same number of OMs, string ids start at 0, OM ids start at 0, and the geo file lists modules string by string. Any geo file that breaks one of these gave hits whose keys are not in the detector, and serialization failed.

Olympus returns one entry per module in `detector.modules` order, so the key is now taken from the module itself. A mismatch between entry count and module count raises instead of misassigning hits.

Tests cover 1-based, uneven, OM-major and non-contiguous numbering.

## 2. Bad geo files fail at load time and say why

A geo file that reuses a string id for two physical strings gives duplicate `(string_id, om_id)` keys. `Detector[key]` returned the first match, so hits went to the wrong module with no error.

`Detector` now validates its modules on construction and raises `GeometryError` listing every problem at once:

- duplicate `(string_id, om_id)` keys
- a string id shared by modules more than 5 m apart in (x, y)
- non-finite positions
- no modules

`detector_from_geo` adds per-line parse errors with line numbers (wrong field count, non-numeric position, non-integer ids, missing `### Modules ###` header, no modules).

Negative ids and strings whose modules drift more than 5 m in (x, y) are legal but unusual, so they warn. The 5 m tolerance leaves room for surveyed drift (IceCube: 0.6 m).

Example output on a file with reused string ids:

```
Invalid geo file bad.geo:
  - 160 duplicate (string_id, om_id) key(s), e.g. (-5, 0), (-5, 1), (-5, 2), (-5, 3), (-5, 4), ... (155 more)
  - 8 string ID(s) shared by modules at different (x, y), so two physical strings carry the same ID: string -5 at (-20, 10); (-10, -20), ... (5 more)
```

## Checks

- All 11 shipped geo files load unchanged and without warnings.
- Fast test suite passes with `-W error::UserWarning` (369 passed).
- Slow water e2e (`--run-slow`, fixed olympus reference hit count) passes.
- ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
