### PR TITLE
Bound GPU memory with a photon chunk size for the olympus sampler

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,42 @@ python examples/<SCRIPT_NAME>
 
 Replace `<SCRIPT_NAME>` with the name of your script: `01_basic_water.py` or `02_basic_ice.py` for a quick-start option.
 
+## Memory on the GPU
+
+Prometheus never batches events together. The photon propagator runs one
+particle at a time, so what sets peak device memory is the single brightest
+particle in the run, not the number of events. A high-energy cascade close to
+the detector can produce millions of detected photons, and the arrival-time
+flow used to be evaluated for all of them in one call.
+
+The relevant settings live under `config.photon_propagator.olympus.simulation`:
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `photon_chunk` | `262144` | Most photons handed to the arrival-time sampler per call. This bounds the sampler's working set to a fixed size however bright the particle. Lower it on a small GPU. |
+| `module_chunk` | `128` | Modules evaluated per model-input call. Keeps that temporary, and the number of compiled kernels, independent of detector size. |
+| `max_distance` | `300.0` | Drops source-module pairs further apart than this before propagation. Changing it changes physics, not just memory. |
+
+Under `config.run`:
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `jax_release_interval` | `0` (off) | Drop the compiled-executable cache every this many propagations. Pair it with `jax_compilation_cache_dir` so recompilation is a disk read. |
+
+JAX itself reserves half of the GPU on start-up. Prometheus sets
+`XLA_PYTHON_CLIENT_MEM_FRACTION=0.5` only when the variable is not already in
+the environment, so on a shared or small card you can override it:
+
+```bash
+XLA_PYTHON_CLIENT_MEM_FRACTION=0.3 python my_run.py
+# or allocate on demand instead of reserving up front
+XLA_PYTHON_CLIENT_PREALLOCATE=false python my_run.py
+```
+
+An out-of-memory error part way through a run is therefore a single bright
+particle, not accumulated events. Lower `photon_chunk` first; if the error
+comes from the model-input step instead, lower `module_chunk`.
+
 ## Getting Help
 
 If something is not working as expected, or you have a question about using this software, feel free to create [a discussion on GitHub](https://github.com/Harvard-Neutrino/prometheus/discussions) and we will address it as soon as we can.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,7 @@ The relevant settings live under `config.photon_propagator.olympus.simulation`:
 | --- | --- | --- |
 | `photon_chunk` | `262144` | Most photons handed to the arrival-time sampler per call. This bounds the sampler's working set to a fixed size however bright the particle. Lower it on a small GPU. |
 | `module_chunk` | `128` | Modules evaluated per model-input call. Keeps that temporary, and the number of compiled kernels, independent of detector size. |
+| `warm_up` | `False` | Experimental. Compile every kernel bucket at start-up so the event loop never pauses to compile and a card that is too small fails immediately. `warm_up_sources` (`4096`) and `warm_up_pairs` (`262144`) set the top of the ladders. Costs about a minute per process on a CPU with the defaults, less with `jax_compilation_cache_dir`. Off until it has had more testing. |
 | `max_distance` | `300.0` | Drops source-module pairs further apart than this before propagation. Changing it changes physics, not just memory. |
 
 Under `config.run`:

--- a/prometheus/config_types.py
+++ b/prometheus/config_types.py
@@ -556,6 +556,13 @@ class OlympusSimConfig(ConfigBase):
         count; see ``sources_to_model_input_chunked``. Results do not depend
         on it. Larger values trade a bigger per-call temporary for fewer
         calls.
+    photon_chunk : int
+        Most photons handed to the arrival-time flow sampler in one call.
+        Events are never batched together; what sets device memory is the
+        number of detected photons of the single brightest particle, and
+        this bounds the sampler's working set at a fixed size however bright
+        it is. Lower it on a small GPU. Results for particles that fit in
+        one chunk do not depend on it. See ``sample_photon_times``.
     max_distance : float
         Maximum source-to-module distance in metres. Pairs beyond it cannot
         contribute hits and are dropped before propagation. Changing it
@@ -575,6 +582,7 @@ class OlympusSimConfig(ConfigBase):
     max_distance: float = 300.0
     min_distance_from_dom: float = 0.1
     module_chunk: int = 128
+    photon_chunk: int = 2**18
 
 
 @dataclass

--- a/prometheus/config_types.py
+++ b/prometheus/config_types.py
@@ -563,6 +563,16 @@ class OlympusSimConfig(ConfigBase):
         this bounds the sampler's working set at a fixed size however bright
         it is. Lower it on a small GPU. Results for particles that fit in
         one chunk do not depend on it. See ``sample_photon_times``.
+    warm_up : bool
+        Experimental, off by default. Compile every kernel bucket at start-up
+        instead of when the first particle needing it arrives. Makes the
+        per-event time flat from the first event and fails fast on a device
+        that cannot hold the largest kernel. Does not change results. Needs
+        more testing before it becomes the standard.
+    warm_up_sources : int
+        Top of the source bucket ladder compiled by ``warm_up``.
+    warm_up_pairs : int
+        Top of the source-module pair bucket ladders compiled by ``warm_up``.
     max_distance : float
         Maximum source-to-module distance in metres. Pairs beyond it cannot
         contribute hits and are dropped before propagation. Changing it
@@ -583,6 +593,9 @@ class OlympusSimConfig(ConfigBase):
     min_distance_from_dom: float = 0.1
     module_chunk: int = 128
     photon_chunk: int = 2**18
+    warm_up: bool = False
+    warm_up_sources: int = 2**12
+    warm_up_pairs: int = 2**18
 
 
 @dataclass

--- a/prometheus/photon_propagation/olympus/event_generation/photon_propagation/norm_flow_photons.py
+++ b/prometheus/photon_propagation/olympus/event_generation/photon_propagation/norm_flow_photons.py
@@ -26,6 +26,69 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+# Photons per jitted flow-sampler call. The sampler's working set scales with
+# the number of photons it is handed, so this is what bounds device memory
+# for a bright particle. 2**18 photons is ~130 MB of float64 conditioner
+# input plus a few multiples of that in spline temporaries.
+DEFAULT_PHOTON_CHUNK = 2**18
+
+
+def sample_photon_times(sample_fn, traf_params, pair_index, key, photon_chunk=DEFAULT_PHOTON_CHUNK):
+    """Sample one arrival time per photon in fixed-size blocks.
+
+    Parameters
+    ----------
+    sample_fn : callable
+        ``sample_fn(traf_params, key)`` returning one sample per row. Rows
+        are independent, so splitting the photon axis is exact.
+    traf_params : np.ndarray
+        Flow parameters per source-module pair, shape (n_pairs, n_params).
+    pair_index : np.ndarray
+        Pair index of each photon, shape (n_photons,). Gathering per block
+        replaces a host-side ``np.repeat`` of every row's parameters, which
+        for a bright particle is tens of bytes per photon times millions of
+        photons.
+    key : jax.random.PRNGKey
+        Key for the draws.
+    photon_chunk : int
+        Most photons handed to ``sample_fn`` at once.
+
+    Returns
+    -------
+    np.ndarray
+        Samples in photon order, shape (n_photons,).
+
+    Notes
+    -----
+    Every block is padded to a power-of-four bucket capped at
+    ``photon_chunk``, so the compiled-executable cache holds at most one
+    executable per bucket up to the cap however bright the particle. A
+    particle that fits in one block is padded exactly as before and uses
+    ``key`` directly, so results for those are unchanged; larger ones draw
+    one subkey per block.
+    """
+    n_photons = int(pair_index.shape[0])
+    if n_photons == 0:
+        return np.empty(0, dtype=np.asarray(traf_params).dtype)
+    chunk = max(1, int(photon_chunk))
+    if n_photons <= chunk:
+        blocks = [(0, n_photons, key)]
+    else:
+        starts = range(0, n_photons, chunk)
+        keys = random.split(key, len(starts))
+        blocks = [(start, min(start + chunk, n_photons), k) for start, k in zip(starts, keys)]
+
+    out = []
+    for start, stop, block_key in blocks:
+        block = np.asarray(traf_params)[pair_index[start:stop]]
+        n = block.shape[0]
+        pad_len = min(next_bucket(n, base=4), chunk) if n < chunk else chunk
+        pad_len = max(pad_len, n)
+        padded = np.pad(block, ((0, pad_len - n), (0, 0)))
+        out.append(np.asarray(sample_fn(padded, block_key))[:n])
+    return np.concatenate(out)
+
+
 # @profile
 def make_generate_norm_flow_photons(
     shape_model_path,
@@ -34,6 +97,7 @@ def make_generate_norm_flow_photons(
     max_distance=300.0,
     min_distance=0.1,
     module_chunk=128,
+    photon_chunk=DEFAULT_PHOTON_CHUNK,
 ):
     shape_config, shape_params = haiku_load(shape_model_path)
     counts_config, counts_params = haiku_load(counts_model_path)
@@ -64,14 +128,6 @@ def make_generate_norm_flow_photons(
     @jax.jit
     def sample_model_inner(traf_params, key):
         return sample_shape_model(dist_builder, traf_params, traf_params.shape[0], key)
-
-    def sample_model(traf_params, key):
-        pad_len = next_bucket(traf_params.shape[0], base=4)
-        padded = jnp.pad(traf_params, ((0, pad_len - traf_params.shape[0]), (0, 0)))
-
-        result = sample_model_inner(padded, key)
-
-        return result[: traf_params.shape[0]]
 
     def generate_norm_flow_photons(
         module_coords,
@@ -185,17 +241,17 @@ def make_generate_norm_flow_photons(
                         f"{_nph[_i]:,}",
                     )
 
-        # Obtain flow parameters and repeat them for each detected photon.
-        # Pad to the next power-of-4 bucket so apply_fn is JIT-compiled once
-        # per bucket size rather than once per unique n_nonzero (same strategy
-        # already used by sample_model for sample_model_inner).
+        # Obtain flow parameters per pair. Pad to the next power-of-4 bucket
+        # so apply_fn is JIT-compiled once per bucket size rather than once
+        # per unique n_nonzero. Photons refer back to their pair by index;
+        # the per-photon parameters are only materialised one block at a
+        # time inside sample_photon_times.
         _n = inp_params_nonzero.shape[0]
         _pad_len = next_bucket(_n, base=4)
         _padded = np.pad(inp_params_nonzero, ((0, _pad_len - _n), (0, 0)))
         traf_params = np.asarray(apply_fn(shape_params, _padded))[:_n]
-        traf_params_rep = np.repeat(traf_params, n_photons_nonzero, axis=0)
-        # Also repeat the geometric time for each detected photon
-        time_geo_rep = np.repeat(time_geo_nonzero, n_photons_nonzero, axis=0).squeeze()
+        pair_index = np.repeat(np.arange(_n), n_photons_nonzero)
+        time_geo_rep = np.asarray(time_geo_nonzero)[pair_index].squeeze()
 
         # Calculate number of photons per module
         # Start with zero array and fill in the poisson samples using distance mask
@@ -206,7 +262,9 @@ def make_generate_norm_flow_photons(
 
         # Sample times from flow
         key, subkey = random.split(key)
-        samples = sample_model(traf_params_rep, subkey)
+        samples = sample_photon_times(
+            sample_model_inner, traf_params, pair_index, subkey, photon_chunk
+        )
 
         times = np.atleast_1d(np.asarray(samples).squeeze() + time_geo_rep)
 

--- a/prometheus/photon_propagation/olympus/event_generation/photon_propagation/norm_flow_photons.py
+++ b/prometheus/photon_propagation/olympus/event_generation/photon_propagation/norm_flow_photons.py
@@ -277,6 +277,86 @@ def make_generate_norm_flow_photons(
 
         return ak.Array(times)
 
+    def warm_up(max_sources, max_pairs):
+        """Compile every kernel bucket up front instead of on first use.
+
+        Experimental and off by default. Drives the generator itself with
+        synthetic inputs built the way ``_propagate_in_range_modules``
+        builds them (same dtypes, same padding rows), sized so that every
+        bucket of the source, pair and photon ladders up to the caps is
+        compiled here rather than when the first particle needing it
+        arrives. A device that cannot hold the largest kernel fails here
+        rather than part way through a run. Physics and random draws are
+        untouched: the event loop's keys are not consumed.
+
+        Parameters
+        ----------
+        max_sources : int
+            Most photon sources one particle is expected to produce. Sets
+            the top of the source bucket ladder.
+        max_pairs : int
+            Most in-range source-module pairs one particle is expected to
+            produce. Sets the top of the pair bucket ladders.
+        """
+        fdt = jnp.zeros(1).dtype
+        key = random.PRNGKey(0)
+
+        # Photon ladder: every power-of-four bucket up to the chunk, then
+        # the chunk itself, with the dtype the conditioner really emits.
+        probe = np.asarray(apply_fn(shape_params, np.zeros((1, 2), dtype=fdt)))
+        n = 1
+        while n < photon_chunk:
+            sample_model_inner(np.zeros((n, probe.shape[1]), dtype=probe.dtype), key)
+            n *= 4
+        sample_model_inner(np.zeros((photon_chunk, probe.shape[1]), dtype=probe.dtype), key)
+
+        # One module chunk packed at the origin, with in-range sources on a
+        # ring around it facing inwards. Every source-module pair then has
+        # the same distance and viewing angle, so one counts-net evaluation
+        # gives the photon budget that lands the same number of detected
+        # photons on every pair, and the nonzero-pair ladder is walked
+        # exactly. Padding rows sit at -1e6 with no photons, as in
+        # _propagate_in_range_modules.
+        n_mod = max(1, int(module_chunk))
+        coords = np.zeros((n_mod, 3))
+        coords[:, 2] = np.linspace(0.0, 0.01, n_mod)
+        eff = np.ones(n_mod)
+        radius = min(5.0, 0.5 * max_distance)
+        radius = max(radius, 2.0 * min_distance)
+        target_photons = 8.0  # detected photons per pair; keeps every pair nonzero
+
+        def run(n_in_range, n_src, n_mod_used):
+            angles = np.linspace(0.0, 2.0 * np.pi, n_in_range, endpoint=False)
+            pos = np.full((n_src, 3), -1e6, dtype=fdt)
+            pos[:n_in_range, 0] = radius * np.cos(angles)
+            pos[:n_in_range, 1] = radius * np.sin(angles)
+            pos[:n_in_range, 2] = 0.0
+            direction = np.zeros((n_src, 3), dtype=fdt)
+            direction[:n_in_range, 0] = -np.cos(angles)
+            direction[:n_in_range, 1] = -np.sin(angles)
+            time = np.zeros((n_src, 1), dtype=fdt)
+            inp = sources_to_model_input(coords[:1], pos[:1], direction[:1], time[:1], c_medium)[0]
+            inp = np.asarray(inp).reshape(1, -1)
+            frac = 10.0 ** float(np.asarray(counts_apply_fn(counts_params, inp)).reshape(-1)[0])
+            nphotons = np.zeros((n_src, 1), dtype=fdt)
+            nphotons[:n_in_range] = target_photons / max(min(frac, 1.0), 1e-12)
+            generate_norm_flow_photons(
+                coords[:n_mod_used], eff[:n_mod_used], pos, direction, time, nphotons, seed=key
+            )
+
+        n = 16
+        while n <= max(16, max_sources):
+            run(n, n, n_mod)
+            n *= 2
+        n = 16
+        while n <= max(16, max_pairs):
+            n_mod_used = min(n_mod, n)
+            n_in = -(-n // n_mod_used)
+            run(n_in, next_bucket(n_in, minimum=16), n_mod_used)
+            n *= 2
+
+    generate_norm_flow_photons.warm_up = warm_up
+    generate_norm_flow_photons.kernels = (apply_fn, counts_apply_fn, sample_model_inner)
     return generate_norm_flow_photons
 
 

--- a/prometheus/photon_propagation/olympus_photon_propagator.py
+++ b/prometheus/photon_propagation/olympus_photon_propagator.py
@@ -157,6 +157,11 @@ class OlympusPhotonPropagator(PhotonPropagator):
             module_chunk=self.config["simulation"].get("module_chunk", 128),
             photon_chunk=self.config["simulation"].get("photon_chunk", DEFAULT_PHOTON_CHUNK),
         )
+        if self.config["simulation"].get("warm_up", False):
+            self._gen_ph.warm_up(
+                self.config["simulation"].get("warm_up_sources", 2**12),
+                self.config["simulation"].get("warm_up_pairs", 2**18),
+            )
 
     def propagate(self, particle: Particle, rng_key):
         """Simulate losses and propagate resulting photons for an input particle.

--- a/prometheus/photon_propagation/olympus_photon_propagator.py
+++ b/prometheus/photon_propagation/olympus_photon_propagator.py
@@ -16,6 +16,7 @@ from .olympus.event_generation.event_generation import (
 )
 from .olympus.event_generation.lightyield import make_realistic_cascade_source
 from .olympus.event_generation.photon_propagation.norm_flow_photons import (
+    DEFAULT_PHOTON_CHUNK,
     make_generate_norm_flow_photons,
 )
 from .olympus.event_generation.utils import sph_to_cart_jnp
@@ -154,6 +155,7 @@ class OlympusPhotonPropagator(PhotonPropagator):
             max_distance=self.config["simulation"]["max_distance"],
             min_distance=self.config["simulation"]["min_distance_from_dom"],
             module_chunk=self.config["simulation"].get("module_chunk", 128),
+            photon_chunk=self.config["simulation"].get("photon_chunk", DEFAULT_PHOTON_CHUNK),
         )
 
     def propagate(self, particle: Particle, rng_key):

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -41,7 +41,10 @@ from .utils.timing import time_block
 # Legacy alias used in this file.
 get_photon_propagator = get_propagator
 
-os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+# Let JAX reserve half the GPU by default. A value already in the environment
+# wins, so a user on a shared or small GPU can lower it (or set
+# XLA_PYTHON_CLIENT_PREALLOCATE=false) without editing this file.
+os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.5")
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_olympus_memory.py
+++ b/tests/test_olympus_memory.py
@@ -8,6 +8,7 @@ that matter most assert that they are numerically indistinguishable from the
 whole-array computations they replaced.
 """
 
+import jax
 import numpy as np
 import pytest
 
@@ -16,6 +17,9 @@ from prometheus.config_types import OlympusSimConfig, RunConfig
 from prometheus.photon_propagation.hit import Hit
 from prometheus.photon_propagation.olympus.event_generation.event_generation import (
     _in_range_masks,
+)
+from prometheus.photon_propagation.olympus.event_generation.photon_propagation import (
+    norm_flow_photons,
 )
 from prometheus.photon_propagation.olympus.event_generation.photon_propagation.utils import (
     next_bucket,
@@ -206,6 +210,102 @@ class TestInRangeMasks:
 # ---------------------------------------------------------------------------
 # Retained hit size and cache release
 # ---------------------------------------------------------------------------
+# sample_photon_times
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSampler:
+    """Stand-in for the jitted flow sampler.
+
+    Returns each row's first parameter so that the gather and ordering can be
+    checked exactly, and records the padded shape of every call so the
+    bucket ladder can be checked.
+    """
+
+    def __init__(self):
+        self.shapes = []
+
+    def __call__(self, traf_params, key):
+        self.shapes.append(traf_params.shape)
+        return traf_params[:, 0]
+
+
+def _pairs_and_photons(rng, n_pairs, n_photons):
+    traf_params = rng.normal(0, 1, (n_pairs, 5))
+    pair_index = np.sort(rng.integers(0, n_pairs, n_photons))
+    return traf_params, pair_index
+
+
+class TestSamplePhotonTimes:
+    @pytest.mark.parametrize(
+        "n_photons, chunk",
+        [
+            (1, 64),  # single photon
+            (50, 64),  # fits in one block
+            (64, 64),  # exactly one block
+            (65, 64),  # one block and a single-photon tail
+            (1000, 64),  # many blocks, ragged tail
+            (1000, 1),  # degenerate chunk size
+        ],
+    )
+    def test_gather_and_order_are_exact(self, n_photons, chunk):
+        rng = np.random.default_rng(0)
+        traf_params, pair_index = _pairs_and_photons(rng, 7, n_photons)
+        key = jax.random.PRNGKey(0)
+        out = norm_flow_photons.sample_photon_times(
+            _RecordingSampler(), traf_params, pair_index, key, chunk
+        )
+        np.testing.assert_array_equal(out, traf_params[pair_index, 0])
+
+    def test_single_block_matches_previous_padding(self):
+        """A particle that fits in one block is padded exactly as before."""
+        rng = np.random.default_rng(1)
+        traf_params, pair_index = _pairs_and_photons(rng, 3, 37)
+        sampler = _RecordingSampler()
+        norm_flow_photons.sample_photon_times(
+            sampler, traf_params, pair_index, jax.random.PRNGKey(0), 2**18
+        )
+        assert sampler.shapes == [(next_bucket(37, base=4), 5)]
+
+    def test_blocks_never_exceed_chunk_and_ladder_is_bounded(self):
+        """The point of the rewrite: device memory bounded however bright."""
+        rng = np.random.default_rng(2)
+        chunk = 256
+        for n_photons in (300, 4_000, 40_000):
+            traf_params, pair_index = _pairs_and_photons(rng, 11, n_photons)
+            sampler = _RecordingSampler()
+            norm_flow_photons.sample_photon_times(
+                sampler, traf_params, pair_index, jax.random.PRNGKey(3), chunk
+            )
+            assert max(n for n, _ in sampler.shapes) <= chunk
+            # Only power-of-four buckets up to the cap can ever be compiled.
+            allowed = {min(4**k, chunk) for k in range(20)}
+            assert {n for n, _ in sampler.shapes} <= allowed
+
+    def test_blocks_draw_distinct_keys(self):
+        """Blocks must not reuse one key, or their samples would repeat."""
+        seen = []
+
+        def sampler(traf_params, key):
+            seen.append(np.asarray(key).tobytes())
+            return np.zeros(traf_params.shape[0])
+
+        rng = np.random.default_rng(4)
+        traf_params, pair_index = _pairs_and_photons(rng, 2, 10)
+        norm_flow_photons.sample_photon_times(
+            sampler, traf_params, pair_index, jax.random.PRNGKey(5), 3
+        )
+        assert len(seen) == 4
+        assert len(set(seen)) == 4
+
+    def test_no_photons(self):
+        out = norm_flow_photons.sample_photon_times(
+            _RecordingSampler(), np.zeros((2, 5)), np.zeros(0, dtype=int), jax.random.PRNGKey(0)
+        )
+        assert out.shape == (0,)
+
+
+# ---------------------------------------------------------------------------
 
 
 class TestHitLayout:
@@ -263,6 +363,12 @@ class TestConfigKnobs:
         assert sim.module_chunk == 128
         sim["module chunk"] = 256
         assert sim.module_chunk == 256
+
+    def test_photon_chunk_default_and_spaced_key(self):
+        sim = OlympusSimConfig()
+        assert sim.photon_chunk == 2**18
+        sim["photon chunk"] = 4096
+        assert sim.photon_chunk == 4096
 
     def test_splitter_still_loads(self):
         """Retained purely so existing configuration files keep working."""

--- a/tests/test_olympus_memory.py
+++ b/tests/test_olympus_memory.py
@@ -8,7 +8,10 @@ that matter most assert that they are numerically indistinguishable from the
 whole-array computations they replaced.
 """
 
+import pathlib
+
 import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -209,6 +212,63 @@ class TestInRangeMasks:
 
 # ---------------------------------------------------------------------------
 # Retained hit size and cache release
+# ---------------------------------------------------------------------------
+# warm_up
+# ---------------------------------------------------------------------------
+
+RESOURCES = pathlib.Path(__file__).parent.parent / "resources" / "olympus_resources"
+
+
+class TestWarmUp:
+    def test_event_after_warm_up_compiles_nothing(self):
+        """Every kernel bucket a run can reach is compiled by the warm-up."""
+        chunk = 256
+        gen = norm_flow_photons.make_generate_norm_flow_photons(
+            str(RESOURCES / "photon_arrival_time_nflow_params.pickle"),
+            str(RESOURCES / "photon_arrival_time_counts_params.pickle"),
+            c_medium=0.2,
+            module_chunk=32,
+            photon_chunk=chunk,
+        )
+        sources_to_model_input._clear_cache()
+        try:
+            gen.warm_up(max_sources=64, max_pairs=64 * 32)
+            sizes = [k._cache_size() for k in gen.kernels] + [sources_to_model_input._cache_size()]
+            assert all(n > 0 for n in sizes)
+
+            # An event shaped and typed the way _propagate_in_range_modules
+            # hands one over: float64 detector arrays, JAX-default-float
+            # sources, times and photon counts as (n, 1) columns, and the
+            # source axis padded to its bucket.
+            fdt = jnp.zeros(1).dtype
+            rng = np.random.default_rng(0)
+            coords = rng.normal(0, 30, (32, 3))
+            source_pos, source_dir, source_time = _random_sources(rng, 64)
+            # Bright enough that the photon count exceeds the chunk, so the
+            # chunk-size sampler kernel is exercised as well as the ladder.
+            gen(
+                coords,
+                np.ones(32),
+                source_pos.astype(fdt),
+                source_dir.astype(fdt),
+                source_time.astype(fdt),
+                np.full((64, 1), 1e6, dtype=fdt),
+                seed=jax.random.PRNGKey(1),
+            )
+            after = [k._cache_size() for k in gen.kernels] + [sources_to_model_input._cache_size()]
+            assert after == sizes
+        finally:
+            sources_to_model_input._clear_cache()
+
+    def test_default_off_and_knobs_load(self):
+        sim = OlympusSimConfig()
+        assert sim.warm_up is False
+        sim["warm up"] = True
+        sim["warm up sources"] = 128
+        sim["warm up pairs"] = 4096
+        assert (sim.warm_up, sim.warm_up_sources, sim.warm_up_pairs) == (True, 128, 4096)
+
+
 # ---------------------------------------------------------------------------
 # sample_photon_times
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses the report that GPU mode "batches events together" and runs out of memory.

## What was actually happening

Prometheus never batches events. The propagation loop runs one particle at a time. What sets peak device memory is the single brightest particle: the arrival-time flow was sampled for every detected photon of that particle in one call, padded up to the next power of four. A high-energy cascade near the detector has millions of photons, each carrying 62 float64 flow parameters, so one particle could ask the GPU for gigabytes on top of the half of the card JAX reserves at start-up.

## Changes

- New `photon_chunk` setting (default `2**18`) under `photon_propagator.olympus.simulation`. `sample_photon_times` walks photons in blocks of at most that size, so the sampler's working set is fixed however bright the particle. The padding ladder is capped at the chunk, so the compiled-executable cache holds at most one executable per power-of-four bucket up to the cap: brighter particles reuse the chunk-size kernel and compile nothing new.
- Photons refer to their source-module pair by index and the per-photon parameters are gathered one block at a time. This also removes a host-side `np.repeat` of about 500 MB per million photons.
- A particle that fits in one block is padded and keyed exactly as before, so its results are unchanged. Larger particles draw one subkey per block.
- `XLA_PYTHON_CLIENT_MEM_FRACTION=0.5` is now set with `setdefault`, so users can lower it or set `XLA_PYTHON_CLIENT_PREALLOCATE=false`.
- Experimental, **off by default**: `warm_up` (with `warm_up_sources`, `warm_up_pairs`) compiles every kernel bucket at start-up by driving the generator with synthetic, production-typed inputs. The event loop then never pauses to compile and a card that is too small fails immediately instead of part way through. About a minute per process on a CPU with the defaults. Needs more testing before it becomes the standard.
- `docs/usage.md` gains a "Memory on the GPU" section listing the settings and the environment variables.

## Checks

- Chunked vs unchunked sampling on the real P-ONE flow (100k photons, 3 pairs): means, spreads and 90% quantiles agree to within sampling noise.
- Compile count with the real jitted sampler: 1, 300, 5k, 70k, 400k and 3M photons at chunk `2**16` compile 4 kernels in total; the 400k and 3M cases compile nothing new.
- Unit tests: exact gather and ordering for single, ragged and degenerate chunks; blocks never exceed the chunk; only power-of-four buckets up to the cap are ever compiled; blocks draw distinct keys; single-block padding matches the old behaviour; after `warm_up` a bright production-shaped event compiles nothing in any of the four kernels; config knobs load with spaced keys and `warm_up` defaults to `False`.
- Fast test suite: 384 passed. Slow water e2e (`--run-slow`, fixed olympus reference hit count): passed.
- ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
