### PR TITLE
Time decay products from the event start across all generations

### DIFF
--- a/prometheus/particle/particle.py
+++ b/prometheus/particle/particle.py
@@ -67,10 +67,11 @@ class PropagatableParticle(Particle):
         Particle which created this particle.
     time : float
         Time in ns at which this particle starts, relative to the primary
-        interaction vertex. 0.0 for interaction-vertex particles; the parent's
-        flight time to the decay vertex for decay products. Required (no
-        default) so that every propagated particle must state its start time —
-        a silently-defaulted time is the Issue #4 bug class.
+        interaction vertex. 0.0 for interaction-vertex particles; the flight
+        time accumulated along the full ancestry chain to the production
+        vertex for decay products. Required (no default) so that every
+        propagated particle must state its start time — a silently-defaulted
+        time is the Issue #4 bug class.
     children : list of Particle
         Particles that this one spawned.
     losses : list

--- a/prometheus/particle/particle_from_proposal.py
+++ b/prometheus/particle/particle_from_proposal.py
@@ -7,7 +7,7 @@ from .particle import PropagatableParticle
 def particle_from_proposal(
     pp_particle,
     coordinate_offset,
-    parent: PropagatableParticle = None,
+    parent: PropagatableParticle,
 ) -> PropagatableParticle:
     """Create a Prometheus particle from a PROPOSAL object.
 
@@ -17,8 +17,9 @@ def particle_from_proposal(
         PROPOSAL particle instance.
     coordinate_offset : np.ndarray
         Coordinate offset to subtract from the particle position.
-    parent : PropagatableParticle, optional
-        Parent particle that created this particle.
+    parent : PropagatableParticle
+        Parent particle that created this particle. Its start time anchors
+        the child's time to the event start.
 
     Returns
     -------
@@ -34,8 +35,12 @@ def particle_from_proposal(
     direction = np.array(
         [pp_particle.direction.x, pp_particle.direction.y, pp_particle.direction.z]
     )
-    # PROPOSAL times are in seconds, relative to the propagation start (the
-    # parent's own start), so this is the parent's flight time to this vertex.
-    time = pp_particle.time * s_to_ns
+    # PROPOSAL times are in seconds and relative to that propagation's own
+    # start (each propagation restarts its clock at 0), so pp_particle.time is
+    # only the parent's flight time to this vertex. The parent's start time
+    # must be added to anchor the child to the event start, as the Particle
+    # time convention requires; without it, chains deeper than one generation
+    # (e.g. tau -> mu -> decay) are timed early by the ancestors' flight time.
+    time = parent.time + pp_particle.time * s_to_ns
     child = PropagatableParticle(pdg_code, e, position, direction, None, parent, time=time)
     return child

--- a/tests/test_decay_chain_timing.py
+++ b/tests/test_decay_chain_timing.py
@@ -1,0 +1,71 @@
+"""Decay-chain start times must accumulate across generations.
+
+PROPOSAL restarts its clock at 0 for every propagation, so a decay product's
+PROPOSAL time only covers its direct parent's flight. ``particle_from_proposal``
+must add the parent's start time so that grandchildren (e.g. tau -> mu ->
+decay) are timed from the event start, not from the intermediate particle's
+start. These tests need no PROPOSAL/PPC installation.
+"""
+
+import numpy as np
+import pytest
+
+from prometheus.particle import PropagatableParticle, particle_from_proposal
+from prometheus.utils.units import s_to_ns
+
+_DIR_Z = np.array([0.0, 0.0, 1.0])
+
+
+class _V:
+    def __init__(self, x, y, z):
+        self.x, self.y, self.z = x, y, z
+
+
+class _PPParticle:
+    """Duck-typed PROPOSAL particle (energy in MeV, position in cm, time in s)."""
+
+    def __init__(self, time_s, z_cm=49000.0):
+        self.type = 13
+        self.energy = 500_000.0
+        self.position = _V(0.0, 0.0, z_cm)
+        self.direction = _V(0.0, 0.0, 1.0)
+        self.time = time_s
+
+
+def _parent(time):
+    return PropagatableParticle(15, 1e3, np.zeros(3), _DIR_Z, 0, None, time=time)
+
+
+class TestFirstGeneration:
+    def test_child_of_event_vertex_parent(self):
+        # parent.time == 0, so the PROPOSAL clock coincides with the event
+        # clock and the child's time is just the converted PROPOSAL time.
+        pp = _PPParticle(time_s=1.634e-6)
+        child = particle_from_proposal(pp, np.zeros(3), parent=_parent(time=0.0))
+        assert child.time == pytest.approx(pp.time * s_to_ns)
+
+    def test_zero_time_stays_zero(self):
+        pp = _PPParticle(time_s=0.0)
+        child = particle_from_proposal(pp, np.zeros(3), parent=_parent(time=0.0))
+        assert child.time == 0.0
+
+
+class TestGrandchild:
+    def test_parent_start_time_is_added(self):
+        parent_start = 1000.0  # ns
+        pp = _PPParticle(time_s=1.634e-6)
+        child = particle_from_proposal(pp, np.zeros(3), parent=_parent(time=parent_start))
+        assert child.time == pytest.approx(parent_start + pp.time * s_to_ns)
+
+
+class TestChainedGenerations:
+    def test_times_accumulate_along_the_chain(self):
+        # tau -> mu: the mu starts at the tau's decay vertex.
+        pp_mu = _PPParticle(time_s=1.0e-6)
+        mu = particle_from_proposal(pp_mu, np.zeros(3), parent=_parent(time=0.0))
+        # mu -> decay product: each PROPOSAL propagation restarts at 0, so the
+        # grandchild's total time must be the sum of both flight times.
+        pp_decay = _PPParticle(time_s=2.5e-7, z_cm=56500.0)
+        grandchild = particle_from_proposal(pp_decay, np.zeros(3), parent=mu)
+        assert grandchild.time == pytest.approx((1.0e-6 + 2.5e-7) * s_to_ns)
+        assert grandchild.parent is mu


### PR DESCRIPTION
Fixes #115.

PROPOSAL restarts its clock at 0 for every propagation, so `pp_particle.time` only covers the direct parent's flight to the decay vertex. Using it as the child's start time is correct for first-generation children of the primary (`parent.time == 0`, the #104 case) but times deeper chains (tau -> mu -> in-volume mu decay) early by the accumulated ancestor flight.

- `time = parent.time + pp_particle.time * s_to_ns`; `parent` is now required, since its start time is load-bearing. The only call site already passes it.
- No double counting: `serialize_loss` only adds each particle's own internal d/c offsets.
- `tests/test_decay_chain_timing.py` covers first generation, grandchild, and a chained tau -> mu -> decay. It needs no PROPOSAL/PPC.

Without the fix the new tests give 1634 ns instead of 2634 ns, and 250 ns instead of 1250 ns. With it the full suite is 388 passed, 1 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ooEifXyvyTqyGiZBnZXW
